### PR TITLE
Add device icons with automatic type detection

### DIFF
--- a/app/utils/device_icons.py
+++ b/app/utils/device_icons.py
@@ -1,0 +1,369 @@
+"""Device type detection and icon mapping for Argus"""
+
+from typing import Optional, List, Dict, Any
+
+
+# Device type constants
+DEVICE_TYPES = {
+    "router": {"label": "Router/Gateway", "icon": "router"},
+    "server": {"label": "Server", "icon": "server"},
+    "desktop": {"label": "Desktop", "icon": "desktop"},
+    "laptop": {"label": "Laptop", "icon": "laptop"},
+    "phone": {"label": "Smartphone", "icon": "phone"},
+    "tablet": {"label": "Tablet", "icon": "tablet"},
+    "tv": {"label": "Smart TV", "icon": "tv"},
+    "gaming": {"label": "Gaming Console", "icon": "gaming"},
+    "iot": {"label": "IoT Device", "icon": "iot"},
+    "printer": {"label": "Printer", "icon": "printer"},
+    "nas": {"label": "Network Storage", "icon": "nas"},
+    "camera": {"label": "Camera/Security", "icon": "camera"},
+    "smart_home": {"label": "Smart Home", "icon": "smart_home"},
+    "access_point": {"label": "Access Point", "icon": "access_point"},
+    "switch": {"label": "Network Switch", "icon": "switch"},
+    "unknown": {"label": "Unknown Device", "icon": "unknown"},
+}
+
+# Vendor patterns for device type detection
+VENDOR_PATTERNS = {
+    # Phones
+    "apple": "phone",
+    "samsung": "phone",
+    "huawei": "phone",
+    "xiaomi": "phone",
+    "oneplus": "phone",
+    "google": "phone",
+    "motorola": "phone",
+    "lg electronics": "phone",
+    "oppo": "phone",
+    "vivo": "phone",
+
+    # Routers/Network
+    "cisco": "router",
+    "netgear": "router",
+    "tp-link": "router",
+    "linksys": "router",
+    "asus": "router",
+    "d-link": "router",
+    "ubiquiti": "access_point",
+    "mikrotik": "router",
+    "juniper": "router",
+    "aruba": "access_point",
+    "ruckus": "access_point",
+    "fortinet": "router",
+    "palo alto": "router",
+    "sonicwall": "router",
+    "watchguard": "router",
+    "zyxel": "router",
+    "draytek": "router",
+
+    # Servers/Compute
+    "dell": "server",
+    "hp": "server",
+    "hewlett packard": "server",
+    "lenovo": "server",
+    "supermicro": "server",
+    "vmware": "server",
+
+    # Smart Home / IoT
+    "amazon": "smart_home",
+    "ring": "camera",
+    "nest": "smart_home",
+    "philips": "smart_home",
+    "sonos": "smart_home",
+    "ecobee": "smart_home",
+    "wemo": "smart_home",
+    "tuya": "iot",
+    "shelly": "iot",
+    "tasmota": "iot",
+    "espressif": "iot",
+    "raspberry": "server",
+
+    # Gaming
+    "sony": "gaming",
+    "nintendo": "gaming",
+    "microsoft": "gaming",
+    "xbox": "gaming",
+    "playstation": "gaming",
+    "valve": "gaming",
+
+    # TVs
+    "roku": "tv",
+    "vizio": "tv",
+    "tcl": "tv",
+    "hisense": "tv",
+    "chromecast": "tv",
+    "fire tv": "tv",
+    "apple tv": "tv",
+
+    # Printers
+    "brother": "printer",
+    "canon": "printer",
+    "epson": "printer",
+    "xerox": "printer",
+    "ricoh": "printer",
+    "kyocera": "printer",
+    "lexmark": "printer",
+
+    # NAS
+    "synology": "nas",
+    "qnap": "nas",
+    "western digital": "nas",
+    "seagate": "nas",
+    "buffalo": "nas",
+    "drobo": "nas",
+
+    # Cameras
+    "hikvision": "camera",
+    "dahua": "camera",
+    "axis": "camera",
+    "wyze": "camera",
+    "eufy": "camera",
+    "reolink": "camera",
+    "arlo": "camera",
+    "blink": "camera",
+}
+
+# Hostname patterns for device type detection
+HOSTNAME_PATTERNS = {
+    # Phones
+    "iphone": "phone",
+    "ipad": "tablet",
+    "android": "phone",
+    "galaxy": "phone",
+    "pixel": "phone",
+
+    # Computers
+    "macbook": "laptop",
+    "imac": "desktop",
+    "mac-mini": "desktop",
+    "macpro": "desktop",
+    "laptop": "laptop",
+    "desktop": "desktop",
+    "workstation": "desktop",
+    "pc": "desktop",
+
+    # Network
+    "router": "router",
+    "gateway": "router",
+    "firewall": "router",
+    "switch": "switch",
+    "ap-": "access_point",
+    "accesspoint": "access_point",
+    "unifi": "access_point",
+
+    # Servers
+    "server": "server",
+    "srv": "server",
+    "nas": "nas",
+    "plex": "server",
+    "proxmox": "server",
+    "esxi": "server",
+    "docker": "server",
+    "kubernetes": "server",
+    "k8s": "server",
+    "pi": "server",
+    "raspberry": "server",
+
+    # Smart Home
+    "echo": "smart_home",
+    "alexa": "smart_home",
+    "google-home": "smart_home",
+    "nest": "smart_home",
+    "hue": "smart_home",
+    "sonos": "smart_home",
+    "homepod": "smart_home",
+
+    # Entertainment
+    "tv": "tv",
+    "roku": "tv",
+    "chromecast": "tv",
+    "firetv": "tv",
+    "appletv": "tv",
+    "shield": "tv",
+    "playstation": "gaming",
+    "xbox": "gaming",
+    "nintendo": "gaming",
+    "ps4": "gaming",
+    "ps5": "gaming",
+
+    # Printers
+    "printer": "printer",
+    "print": "printer",
+    "laserjet": "printer",
+    "deskjet": "printer",
+    "officejet": "printer",
+
+    # Cameras
+    "camera": "camera",
+    "cam": "camera",
+    "ipcam": "camera",
+    "dvr": "camera",
+    "nvr": "camera",
+}
+
+# OS patterns for device type detection
+OS_PATTERNS = {
+    "ios": "phone",
+    "iphone": "phone",
+    "ipad": "tablet",
+    "android": "phone",
+    "windows phone": "phone",
+    "windows server": "server",
+    "windows": "desktop",
+    "macos": "desktop",
+    "mac os": "desktop",
+    "linux": "server",
+    "ubuntu": "server",
+    "debian": "server",
+    "centos": "server",
+    "red hat": "server",
+    "freebsd": "server",
+    "openwrt": "router",
+    "routeros": "router",
+    "junos": "router",
+    "ios-xe": "router",
+    "nx-os": "switch",
+    "freenas": "nas",
+    "truenas": "nas",
+    "synology": "nas",
+    "pfsense": "router",
+    "opnsense": "router",
+    "proxmox": "server",
+    "esxi": "server",
+    "vmware": "server",
+    "playstation": "gaming",
+    "xbox": "gaming",
+    "nintendo": "gaming",
+    "tizen": "tv",
+    "webos": "tv",
+    "roku": "tv",
+    "fire os": "tv",
+    "tvos": "tv",
+}
+
+# Port-based hints (less reliable, used as fallback)
+PORT_HINTS = {
+    # Server ports
+    (22, 80, 443): "server",
+    (22,): "server",
+    (3389,): "desktop",  # RDP suggests Windows desktop
+    (5900, 5901): "desktop",  # VNC
+    (8080, 8443): "server",
+    (9000, 9090): "server",
+
+    # Printer ports
+    (515, 631, 9100): "printer",
+    (9100,): "printer",
+    (631,): "printer",
+
+    # NAS ports
+    (5000, 5001): "nas",  # Synology
+    (8080, 443, 22): "nas",
+
+    # Smart home
+    (8123,): "smart_home",  # Home Assistant
+    (1883,): "iot",  # MQTT
+
+    # Media
+    (32400,): "server",  # Plex
+    (8096,): "server",  # Jellyfin
+}
+
+
+def detect_device_type(
+    vendor: Optional[str] = None,
+    hostname: Optional[str] = None,
+    os_name: Optional[str] = None,
+    device_type: Optional[str] = None,
+    ports: Optional[List[int]] = None,
+    mac_address: Optional[str] = None,
+    ip_address: Optional[str] = None,
+) -> str:
+    """
+    Detect device type based on available information.
+
+    Returns the device type key (e.g., 'router', 'phone', 'server').
+    Priority: explicit device_type > vendor > hostname > OS > ports > IP hints
+    """
+    # If device_type is already set and valid, use it
+    if device_type and device_type.lower() in DEVICE_TYPES:
+        return device_type.lower()
+
+    # Check if IP suggests a gateway (common gateway IPs)
+    if ip_address:
+        if ip_address.endswith(".1") or ip_address.endswith(".254"):
+            # Could be a router, but check other hints first
+            pass
+
+    # Check vendor
+    if vendor:
+        vendor_lower = vendor.lower()
+        for pattern, dtype in VENDOR_PATTERNS.items():
+            if pattern in vendor_lower:
+                return dtype
+
+    # Check hostname
+    if hostname:
+        hostname_lower = hostname.lower()
+        for pattern, dtype in HOSTNAME_PATTERNS.items():
+            if pattern in hostname_lower:
+                return dtype
+
+    # Check OS
+    if os_name:
+        os_lower = os_name.lower()
+        for pattern, dtype in OS_PATTERNS.items():
+            if pattern in os_lower:
+                return dtype
+
+    # Check ports (least reliable)
+    if ports:
+        port_set = set(ports)
+        for port_tuple, dtype in PORT_HINTS.items():
+            if set(port_tuple).issubset(port_set):
+                return dtype
+
+    # Gateway IP hint (fallback)
+    if ip_address and (ip_address.endswith(".1") or ip_address.endswith(".254")):
+        return "router"
+
+    return "unknown"
+
+
+def get_device_icon_info(device_type: str) -> Dict[str, str]:
+    """Get icon info for a device type."""
+    return DEVICE_TYPES.get(device_type, DEVICE_TYPES["unknown"])
+
+
+def detect_and_get_icon(
+    vendor: Optional[str] = None,
+    hostname: Optional[str] = None,
+    os_name: Optional[str] = None,
+    device_type: Optional[str] = None,
+    ports: Optional[List[int]] = None,
+    mac_address: Optional[str] = None,
+    ip_address: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Detect device type and return icon information.
+
+    Returns dict with:
+    - type: device type key
+    - label: human-readable label
+    - icon: icon identifier
+    """
+    dtype = detect_device_type(
+        vendor=vendor,
+        hostname=hostname,
+        os_name=os_name,
+        device_type=device_type,
+        ports=ports,
+        mac_address=mac_address,
+        ip_address=ip_address,
+    )
+    info = get_device_icon_info(dtype)
+    return {
+        "type": dtype,
+        "label": info["label"],
+        "icon": info["icon"],
+    }

--- a/templates/device_detail.html
+++ b/templates/device_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "partials/device_icons.html" import device_icon, device_badge %}
 
 {% block title %}{{ device.ip_address }} - Argus{% endblock %}
 {% block page_title %}Device Details{% endblock %}
@@ -72,12 +73,20 @@
 <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700 rounded-lg overflow-hidden">
     <div class="px-4 py-5 sm:px-6 bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
         <div class="flex items-center justify-between">
-            <div>
-                <h3 class="text-lg font-medium text-gray-900 dark:text-white">{{ device.ip_address }}</h3>
-                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ device.hostname or 'No hostname' }}</p>
-                {% if device.device_type %}
-                <p class="mt-1 text-sm font-medium text-indigo-600 dark:text-indigo-400">{{ device.device_type }}</p>
-                {% endif %}
+            <div class="flex items-center">
+                {# Device type icon #}
+                {% set icon_type = get_device_icon_type(device) %}
+                {% set icon_info = get_device_icon_info(icon_type) %}
+                <div class="flex-shrink-0 mr-4 p-3 bg-gray-100 dark:bg-gray-600 rounded-lg">
+                    <span class="text-gray-500 dark:text-gray-300">
+                        {{ device_icon(icon_type, "8") }}
+                    </span>
+                </div>
+                <div>
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-white">{{ device.ip_address }}</h3>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ device.hostname or 'No hostname' }}</p>
+                    <p class="mt-1 text-sm font-medium text-indigo-600 dark:text-indigo-400">{{ device.device_type or icon_info.label }}</p>
+                </div>
             </div>
             <div class="flex items-center space-x-2">
                 <!-- Scan This Device Button -->

--- a/templates/devices.html
+++ b/templates/devices.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "partials/device_icons.html" import device_icon %}
 
 {% block title %}Devices - Argus{% endblock %}
 {% block page_title %}Devices{% endblock %}
@@ -190,8 +191,13 @@
                 data-port-count="{{ device.ports|length }}">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 dark:text-white">
                     <div class="flex items-center">
+                        {# Device type icon #}
+                        {% set icon_type = get_device_icon_type(device) %}
+                        <span class="mr-2 text-gray-400 dark:text-gray-500" title="{{ get_device_icon_info(icon_type).label }}">
+                            {{ device_icon(icon_type, "5") }}
+                        </span>
                         {% if device.risk_level in ['high', 'critical'] %}
-                        <svg class="h-4 w-4 text-red-500 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                        <svg class="h-4 w-4 text-red-500 mr-1" viewBox="0 0 20 20" fill="currentColor">
                             <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
                         </svg>
                         {% endif %}

--- a/templates/partials/device_icons.html
+++ b/templates/partials/device_icons.html
@@ -1,0 +1,107 @@
+{# Device Icon Macros for Argus #}
+
+{% macro device_icon(icon_type, size="6", css_class="") %}
+{# Render a device icon SVG based on type #}
+{% set icon_class = "h-" ~ size ~ " w-" ~ size ~ " " ~ css_class %}
+
+{% if icon_type == "router" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Router/Gateway">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
+</svg>
+
+{% elif icon_type == "server" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Server">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/>
+</svg>
+
+{% elif icon_type == "desktop" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Desktop">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+</svg>
+
+{% elif icon_type == "laptop" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Laptop">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+</svg>
+
+{% elif icon_type == "phone" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Smartphone">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+</svg>
+
+{% elif icon_type == "tablet" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Tablet">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+</svg>
+
+{% elif icon_type == "tv" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Smart TV">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+</svg>
+
+{% elif icon_type == "gaming" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Gaming Console">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/>
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+</svg>
+
+{% elif icon_type == "iot" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="IoT Device">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/>
+</svg>
+
+{% elif icon_type == "printer" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Printer">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/>
+</svg>
+
+{% elif icon_type == "nas" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Network Storage">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/>
+</svg>
+
+{% elif icon_type == "camera" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Camera/Security">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/>
+</svg>
+
+{% elif icon_type == "smart_home" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Smart Home">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+</svg>
+
+{% elif icon_type == "access_point" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Access Point">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"/>
+</svg>
+
+{% elif icon_type == "switch" %}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Network Switch">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+</svg>
+
+{% else %}
+{# Unknown/default device icon #}
+<svg class="{{ icon_class }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" title="Unknown Device">
+    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+</svg>
+{% endif %}
+{% endmacro %}
+
+
+{% macro device_icon_with_label(icon_type, label, size="6", css_class="") %}
+{# Render device icon with a label below it #}
+<div class="flex flex-col items-center">
+    {{ device_icon(icon_type, size, css_class) }}
+    <span class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ label }}</span>
+</div>
+{% endmacro %}
+
+
+{% macro device_badge(icon_type, label, size="5", css_class="") %}
+{# Render a compact device badge with icon and label #}
+<div class="inline-flex items-center space-x-1.5 px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-md {{ css_class }}">
+    {{ device_icon(icon_type, size, "text-gray-600 dark:text-gray-400") }}
+    <span class="text-xs font-medium text-gray-700 dark:text-gray-300">{{ label }}</span>
+</div>
+{% endmacro %}

--- a/templates/visualization.html
+++ b/templates/visualization.html
@@ -171,17 +171,20 @@
                     <a :href="'/devices/' + device.id"
                        class="heatmap-cell p-3 rounded-lg border-2 relative"
                        :class="getHeatmapCellClass(device.risk_level)">
+                        <div class="flex items-start justify-between mb-1">
+                            <span class="text-gray-400 dark:text-gray-500" x-html="getDeviceIconSvg(device.icon_type)" :title="device.device_type_label"></span>
+                            <!-- Trusted badge -->
+                            <div x-show="device.is_trusted">
+                                <svg class="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                                </svg>
+                            </div>
+                        </div>
                         <div class="text-sm font-medium truncate" x-text="device.label"></div>
                         <div class="text-xs text-gray-500 dark:text-gray-400 truncate" x-text="device.ip"></div>
                         <div class="mt-2 flex items-center justify-between">
                             <span class="text-xs" x-text="device.zone"></span>
                             <span class="text-xs font-bold" x-text="device.risk_score"></span>
-                        </div>
-                        <!-- Trusted badge -->
-                        <div x-show="device.is_trusted" class="absolute top-1 right-1">
-                            <svg class="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
                         </div>
                     </a>
                 </template>
@@ -484,6 +487,28 @@ function visualizationApp() {
                 'none': 'bg-gray-50 dark:bg-gray-700/30 border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700/50'
             };
             return classes[risk] || classes['none'];
+        },
+
+        getDeviceIconSvg(iconType) {
+            const icons = {
+                'router': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/></svg>',
+                'server': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/></svg>',
+                'desktop': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>',
+                'laptop': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg>',
+                'phone': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg>',
+                'tablet': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 18h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg>',
+                'tv': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>',
+                'gaming': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>',
+                'iot': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z"/></svg>',
+                'printer': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"/></svg>',
+                'nas': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>',
+                'camera': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>',
+                'smart_home': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/></svg>',
+                'access_point': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.141 0M1.394 9.393c5.857-5.857 15.355-5.857 21.213 0"/></svg>',
+                'switch': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>',
+                'unknown': '<svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>'
+            };
+            return icons[iconType] || icons['unknown'];
         },
 
         getTimelineEventClass(event) {


### PR DESCRIPTION
## Summary
- Add smart device type detection based on vendor, hostname, OS, ports, and IP patterns
- Display device-specific icons throughout the UI for better visual identification
- Support 16 device types: router, server, desktop, laptop, phone, tablet, TV, gaming, IoT, printer, NAS, camera, smart home, access point, switch, unknown

## Changes
- `app/utils/device_icons.py` - New utility for device type detection with pattern matching
- `app/main.py` - Added template globals for icon detection
- `templates/partials/device_icons.html` - Reusable Jinja macros for SVG icons
- `templates/devices.html` - Device icons in list view
- `templates/device_detail.html` - Large icon in device header
- `templates/visualization.html` - Icons in heatmap cells

## Detection Priority
1. Explicit device_type field (if set)
2. Vendor name patterns (Apple, Cisco, Samsung, etc.)
3. Hostname patterns (iphone, server, printer, etc.)
4. OS name patterns (iOS, Windows Server, Linux, etc.)
5. Open port hints (9100→printer, 22→server, etc.)
6. IP address hints (.1/.254→router)

## Test plan
- [ ] View device list - icons appear next to IP addresses
- [ ] View device detail - large icon in header with type label
- [ ] View visualization heatmap - icons in each device cell
- [ ] Verify different device types show appropriate icons
- [ ] Test dark mode compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)